### PR TITLE
Updated merge to version >=1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3716,7 +3716,7 @@
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
       "integrity": "sha1-Kl5//L19C6J1W97LFuWkJ9+97DY=",
       "requires": {
-        "merge": "^1.2.0"
+        "merge": ">=1.2.1"
       }
     },
     "execa": {
@@ -6677,7 +6677,7 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
+      "version": ">=1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },


### PR DESCRIPTION
Updated every instance of merge in the package-lock.json file to version ">=1.2.1" because of the [CVE-2018-16469](https://nvd.nist.gov/vuln/detail/CVE-2018-16469) High Severity security alert.